### PR TITLE
Endianness enhancements

### DIFF
--- a/pkg/mmap/NAMESPACE
+++ b/pkg/mmap/NAMESPACE
@@ -32,7 +32,6 @@ export(
 
        as.Ctype,
        is.Ctype,
-       nbytes,
 
        dim.mmap, "dim<-.mmap",
        dimnames.mmap, "dimnames<-.mmap",
@@ -88,12 +87,10 @@ S3method(as.int16, mmap)
 S3method(as.uint16, mmap)
 S3method(as.int24, mmap)
 
-S3method(nbytes, Ctype)
-S3method(nbytes, mmap)
-
 S3method(sizeof, default)
 S3method(sizeof, Ctype)
 S3method(sizeof, "function")
+S3method(sizeof, mmap)
 
 S3method(pad, default)
 S3method(pad, Ctype)

--- a/pkg/mmap/R/mmap.csv.R
+++ b/pkg/mmap/R/mmap.csv.R
@@ -18,7 +18,7 @@ function (file, header = TRUE, sep = ",", quote = "\"", dec = ".",
     tmplist[[col]] <- as.mmap(clm[,1], force=TRUE) 
   }
   stype <- do.call(struct,lapply(tmplist, function(X) X$storage.mode))
-  totalsize <- sum(sapply(tmplist, nbytes))
+  totalsize <- sum(sapply(tmplist, sizeof))
   tmpstruct <- tempfile()
   writeBin(raw(totalsize), tmpstruct)
   tmpstruct <- mmap(tmpstruct, stype)


### PR DESCRIPTION
Resolve #10. This should allow the backing files to be more portable and useful for persisting data across machines. The default byte order is big endian to correspond with network byte order (i.e. the XDR endianness). Once we implement a way to save the `Ctype` attributes to the backing files, the default byte order should be switched to "platform" to enhance performance without introducing ambiguity. Some work was also done to pave the way for #1, #12, #15, and #13.