### PR TITLE
Type support enhancements

### DIFF
--- a/pkg/mmap/NAMESPACE
+++ b/pkg/mmap/NAMESPACE
@@ -17,7 +17,7 @@ export(
        extractFUN, "extractFUN<-",
        replaceFUN, "replaceFUN<-",
 
-       bitset,  # not yet implemented
+       bitset,
        bool8, bool32,
        char,  int8,  int16,  int32,  
        uchar, uint8, uint16, int64,
@@ -64,6 +64,7 @@ S3method(as.mmap, complex)
 S3method(as.mmap, double)
 S3method(as.mmap, integer)
 S3method(as.mmap, character)
+S3method(as.mmap, logical)
 
 # R object default conversion
 S3method(as.mmap, matrix)

--- a/pkg/mmap/NAMESPACE
+++ b/pkg/mmap/NAMESPACE
@@ -17,8 +17,8 @@ export(
        extractFUN, "extractFUN<-",
        replaceFUN, "replaceFUN<-",
 
-       bits,  # not yet implemented
-       logi8, logi32,
+       bitset,  # not yet implemented
+       bool8, bool32,
        char,  int8,  int16,  int32,  
        uchar, uint8, uint16, int64,
        real32, real64,
@@ -31,6 +31,7 @@ export(
 
        as.Ctype,
        is.Ctype,
+       get.Ctype,
 
        dim.mmap, "dim<-.mmap",
        dimnames.mmap, "dimnames<-.mmap",
@@ -85,6 +86,8 @@ S3method(as.int8, mmap)
 S3method(as.uint8, mmap)
 S3method(as.int16, mmap)
 S3method(as.uint16, mmap)
+
+S3method(get.Ctype, Ctype)
 
 S3method(sizeof, default)
 S3method(sizeof, Ctype)

--- a/pkg/mmap/NAMESPACE
+++ b/pkg/mmap/NAMESPACE
@@ -27,7 +27,6 @@ export(
        pad,
 
        struct,
-       as.struct,
        is.struct,
 
        as.Ctype,
@@ -71,7 +70,6 @@ S3method(as.mmap, data.frame)
 
 # methods to handle conversion to internal Ctype
 S3method("[[<-", struct)
-S3method(as.struct, default)
 S3method(as.Ctype, Ctype)
 S3method(as.Ctype, logical)
 S3method(as.Ctype, character)
@@ -79,6 +77,8 @@ S3method(as.Ctype, complex)
 S3method(as.Ctype, double)
 S3method(as.Ctype, integer)
 S3method(as.Ctype, raw)
+S3method(as.Ctype, NULL)
+S3method(as.Ctype, default)
 S3method(as.char, mmap)
 S3method(as.uchar, mmap)
 S3method(as.int8, mmap)

--- a/pkg/mmap/NAMESPACE
+++ b/pkg/mmap/NAMESPACE
@@ -19,11 +19,11 @@ export(
 
        bits,  # not yet implemented
        logi8, logi32,
-       char,  int8,  int16,  int24,  int32,  
-       uchar, uint8, uint16, uint24, int64,
+       char,  int8,  int16,  int32,  
+       uchar, uint8, uint16, int64,
        real32, real64,
        cplx,
-       as.uchar, as.char, as.int8, as.uint8, as.int16, as.uint16, as.int24,
+       as.uchar, as.char, as.int8, as.uint8, as.int16, as.uint16,
        pad,
 
        struct,
@@ -85,7 +85,6 @@ S3method(as.int8, mmap)
 S3method(as.uint8, mmap)
 S3method(as.int16, mmap)
 S3method(as.uint16, mmap)
-S3method(as.int24, mmap)
 
 S3method(sizeof, default)
 S3method(sizeof, Ctype)

--- a/pkg/mmap/R/methods.R
+++ b/pkg/mmap/R/methods.R
@@ -34,25 +34,27 @@ dim.mmap <- function(x) {
   if( is.null(value)) {
     x$dim <- value
   } else
-  if( length(value) != 2) {
+  if( length(value) != 2)
     stop("only dimension of length two supported")
-  } else x$dim <- as.integer(value)
+  else
+    x$dim <- as.integer(value)
   x
 }
 
 dimnames.mmap <- function(x) {
   if( is.struct(x$storage.mode))
     list(NULL, names(x$storage.mode))
-  else x$dimnames
+  else
+    x$dimnames
 }
 
 `dimnames<-.mmap` <- function(x, value) {
   if( is.null(dim(x)))
     stop("'dimnames' applied to non-array")
-  if( is.struct(x$storage.mode)) {
+  if( is.struct(x$storage.mode))
     names(x$storage.mode) <- value[[2]]
+  else
     x$dimnames <- value
-  } else x$dimnames <- value
   x
 }
 

--- a/pkg/mmap/R/mmap.R
+++ b/pkg/mmap/R/mmap.R
@@ -77,10 +77,10 @@ print.mmap <- function(x, ...) {
               }
   }
   if( !is.null(x$dim)) { # has dim
-  cat(paste("<mmap:",file_name,">  (",class(x$storage.mode)[2],") ",
+  cat(paste("<mmap:",file_name,">  (",get.Ctype(x$storage.mode),") ",
             type_name," [1:", nrow(x),", 1:", ncol(x),"]",sep=""),firstN,"...\n")
   } else {
-  cat(paste("<mmap:",file_name,">  (",class(x$storage.mode)[2],") ",
+  cat(paste("<mmap:",file_name,">  (",get.Ctype(x$storage.mode),") ",
             type_name," [1:", length(x),"]",sep=""),firstN,"...\n")
   }
 }
@@ -274,7 +274,7 @@ normalize.encoding <- function(x, to) {
 length.mmap <- function(x) {
   size_in_bytes <- sizeof(x)
   size <- sizeof(x$storage.mode)
-  if( class(x$storage.mode)[2] == 'bits')
+  if( get.Ctype(x$storage.mode) == "bitset")
     trunc(size_in_bytes/size) * 32L
   else
     trunc(size_in_bytes/size)

--- a/pkg/mmap/R/mmap.R
+++ b/pkg/mmap/R/mmap.R
@@ -314,10 +314,7 @@ as.mmap.integer <- function(x,
                             ...) {
   mode <- as.Ctype(mode)
   nbytes <- sizeof(mode)
-  if(nbytes == 3)
-    writeBin(writeBin(x,raw())[1:(length(x)*4) %% 4 != 0], file, endian=attr(mode, "endian"))
-  else
-    writeBin(x, file, size=nbytes, endian=attr(mode, "endian"))
+  writeBin(x, file, size=nbytes, endian=attr(mode, "endian"))
   mmap(file, mode)
 }
 as.mmap.double <- function(x,

--- a/pkg/mmap/R/mmap.R
+++ b/pkg/mmap/R/mmap.R
@@ -302,43 +302,32 @@ as.mmap <- function(x, mode, file,...) {
   UseMethod("as.mmap")
 }
 
-as.mmap.raw <- function(x, mode=raw(), file=tempmmap(), ...) {
+as.mmap.raw <- function(x, mode=as.Ctype(x, ...), file=tempmmap(), ...) {
   mode <- as.Ctype(mode)
   writeBin(x, file)
   mmap(file, mode)
 }
 
-as.mmap.integer <- function(x,
-                            mode=integer(),
-                            file=tempmmap(),
-                            ...) {
+as.mmap.integer <- function(x, mode=as.Ctype(x, ...), file=tempmmap(), ...) {
   mode <- as.Ctype(mode)
   nbytes <- sizeof(mode)
   writeBin(x, file, size=nbytes, endian=attr(mode, "endian"))
   mmap(file, mode)
 }
-as.mmap.double <- function(x,
-                            mode=double(),
-                            file=tempmmap(),
-                            ...) {
+as.mmap.double <- function(x, mode=as.Ctype(x, ...), file=tempmmap(), ...) {
   mode <- as.Ctype(mode)
   nbytes <- sizeof(mode)
   writeBin(x, file, size=nbytes, endian=attr(mode, "endian"))
   mmap(file, mode)
 }
-as.mmap.complex <- function(x,
-                            mode=complex(),
-                            file=tempmmap(),
-                            ...) {
+as.mmap.complex <- function(x, mode=as.Ctype(x, ...), file=tempmmap(), ...) {
   mode <- as.Ctype(mode)
   nbytes <- sizeof(mode)
   writeBin(x, file, size=nbytes, endian=attr(mode, "endian"))
   mmap(file, mode)
 }
 
-as.mmap.character <- function(x, 
-                              mode=char(sample=x),
-                              file=tempmmap(), ...) {
+as.mmap.character <- function(x, mode=as.Ctype(x, ...), file=tempmmap(), ...) {
   mode <- as.Ctype(mode)
   payload.cap <- sizeof(mode) - 1
   nas <- is.na(x)
@@ -368,7 +357,7 @@ as.mmap.character <- function(x,
   mmap(file, mode)
 }
 
-as.mmap.matrix <- function(x, mode = as.Ctype(x), file=tempmmap(), ...) {
+as.mmap.matrix <- function(x, mode=as.Ctype(x, ...), file=tempmmap(), ...) {
   DIM <- dim(x)
   dim(x) <- NULL
   x <- as.mmap(x, mode, file, ...)
@@ -376,14 +365,12 @@ as.mmap.matrix <- function(x, mode = as.Ctype(x), file=tempmmap(), ...) {
   x
 }
 
-as.mmap.data.frame <- function(x, mode, file, ...) {
+as.mmap.data.frame <- function(x, mode, file=tempmmap(), ...) {
   if( !missing(mode))
     warning("'mode' argument currently unsupported")
-  mode <- as.struct(x)
-  tmp <- tempfile()
-  writeBin(raw(sizeof(mode) * NROW(x)), tmp)
-  m <- mmap(tmp, mode, extractFUN=as.data.frame)
-  dimnames(m) <- list(NULL, colnames(x))
+  mode <- as.Ctype(x, ...)
+  writeBin(raw(sizeof(mode) * NROW(x)), file)
+  m <- mmap(file, mode, extractFUN=as.data.frame)
   for(i in 1:NCOL(x)) {
     m[,i] <- x[,i]
   }

--- a/pkg/mmap/R/mmap.R
+++ b/pkg/mmap/R/mmap.R
@@ -261,7 +261,7 @@ normalize.encoding <- function(x, to) {
       else if (sizeof(x$storage.mode[[j[fi]]]) > 1)
         swap.byte.order[fi] <- attr(x$storage.mode[[j[fi]]], "endian") != .Platform$endian
   } else if (inherits(x$storage.mode, "string")) {
-    value <- normalize.encoding(value, attr(x$storage.mode, "enc"))
+    value <- normalize.encoding(as.character(value), attr(x$storage.mode, "enc"))
   } else if (sizeof(x$storage.mode) > 1) {
     swap.byte.order <- attr(x$storage.mode, "endian") != .Platform$endian
   }

--- a/pkg/mmap/R/types.R
+++ b/pkg/mmap/R/types.R
@@ -70,7 +70,7 @@ string <- function(length=NULL, enc=NULL, nul=TRUE, sample=NULL) {
     enc <- "latin1"
     length <- 0
   }
-  structure(character(0), bytes=as.integer(max(length,1)+!!nul), signed=0L,
+  structure(character(0), bytes=as.integer(max(length,1)+!!nul),
             enc=enc, nul=nul, class=c("string","Ctype"))
 }
 as.string <- function(x, ...) UseMethod("as.string")
@@ -140,6 +140,11 @@ int32 <- function(endian=c("big", "little", "swap", "platform")) {
   structure(integer(0), bytes=4L, signed=1L, endian=endian, class=c("int32","Ctype"))
 }
 
+uint32 <- function(endian=c("big", "little", "swap", "platform")) {
+  endian <- normalize.endianness(match.arg(endian))
+  structure(integer(0), bytes=4L, signed=0L, endian=endian, class=c("uint32","Ctype"))
+}
+
 int64 <- function(endian=c("big", "little", "swap", "platform")) {
   endian <- normalize.endianness(match.arg(endian))
   # currently untested and experimental. Will lose precision in R though we cast
@@ -149,46 +154,41 @@ int64 <- function(endian=c("big", "little", "swap", "platform")) {
   structure(double(0), bytes=as.integer(.Machine$sizeof.long), signed=1L, endian=endian, class=c("int64","Ctype"))
 }
 
-uint32 <- function(endian=c("big", "little", "swap", "platform")) {
-  endian <- normalize.endianness(match.arg(endian))
-  structure(integer(0), bytes=4L, signed=0L, endian=endian, class=c("uint32","Ctype"))
-}
-
 real32 <- function(endian=c("big", "little", "swap", "platform")) { 
   endian <- normalize.endianness(match.arg(endian))
-  structure(double(0),  bytes=4L, signed=1L, endian=endian, class=c("float","Ctype"))
+  structure(double(0), bytes=4L, endian=endian, class=c("float","Ctype"))
 }
 
 real64 <- function(endian=c("big", "little", "swap", "platform")) { 
   endian <- normalize.endianness(match.arg(endian))
-  structure(double(0),  bytes=8L, signed=1L, endian=endian, class=c("double","Ctype"))
+  structure(double(0), bytes=8L, endian=endian, class=c("double","Ctype"))
 }
 
 cplx <- function(endian=c("big", "little", "swap", "platform")) {
   endian <- normalize.endianness(match.arg(endian))
-  structure(complex(0),  bytes=16L, signed=1L, endian=endian, class=c("complex","Ctype"))
+  structure(complex(0), bytes=16L, endian=endian, class=c("complex","Ctype"))
 }
 
 bitset <- function(endian=c("big", "little", "swap", "platform")) {
   endian <- normalize.endianness(match.arg(endian))
-  structure(logical(0), bytes=4L, signed=0L, endian=endian, class=c("bitset","Ctype"))
+  structure(logical(0), bytes=4L, endian=endian, class=c("bitset","Ctype"))
 }
 
 bool32 <- function(endian=c("big", "little", "swap", "platform")) {
   endian <- normalize.endianness(match.arg(endian))
-  structure(logical(0), bytes=4L, signed=0L, endian=endian, class=c("bool32","Ctype"))
+  structure(logical(0), bytes=4L, endian=endian, class=c("bool32","Ctype"))
 }
 
 bool8 <- function() {
-  structure(logical(0), bytes=1L, signed=0L, class=c("bool8","Ctype"))
+  structure(logical(0), bytes=1L, class=c("bool8","Ctype"))
 }
 
 pad <- function(...) {
   UseMethod("pad")
 }
 
-pad.default <- function(length=0, ...) {
-  structure(NA_integer_, bytes=length, class=c("pad","Ctype"))
+pad.default <- function(length=0L, ...) {
+  structure(NA_integer_, bytes=as.integer(length), class=c("pad","Ctype"))
 }
 
 pad.Ctype <- function(ctype, ...) {
@@ -207,10 +207,8 @@ struct <- function (..., bytes, offset) {
       dots <- dots[-padding]
       offset <- offset[-padding]
     }
-    structure(dots, bytes = as.integer(sum(bytes_)), 
-                    offset = as.integer(offset), 
-                    signed = NA, 
-              class = c("struct","Ctype"))
+    structure(dots, bytes=as.integer(sum(bytes_)), offset=as.integer(offset), 
+              class=c("struct","Ctype"))
 }
 
 as.list.Ctype <- struct

--- a/pkg/mmap/R/types.R
+++ b/pkg/mmap/R/types.R
@@ -13,45 +13,25 @@ is.Ctype <- function(x) inherits(x, "Ctype")
 as.Ctype.Ctype <- function(x, ...) x
 
 as.Ctype.integer <- function(x, ...) {
-  if(length(x) == 1 && x==0)
-    int32(...)
-  else
-    int32(length(x), ...)
+  int32(...)
 }
 as.Ctype.double <- function(x, ...) {
-  csingle <- attr(x, "Csingle")
-  if( !is.null(csingle) && isTRUE(csingle)) {
-    if(length(x) == 1 && x==0)
-      real32(...)
-    else
-      real32(length(x), ...)
-  } else {
-    if(length(x) == 1 && x==0)
-      real64(...)
-    else
-      real64(length(x), ...)
-  }
+  if( isTRUE(attr(x, "Csingle")))
+    real32(...)
+  else
+    real64(...)
 }
 as.Ctype.raw <- function(x, ...) {
-  if(length(x) == 1 && x==0)
-    uchar(...)
-  else
-    uchar(length(x), ...)
+  uchar(...)
 }
 as.Ctype.character <- function(x, ...) {
   char(sample=x, ...)
 }
 as.Ctype.complex <- function(x, ...) {
-  if(length(x) == 1 && x==0)
-    cplx(...)
-  else
-    cplx(length(x), ...)
+  cplx(...)
 }
 as.Ctype.logical <- function(x, ...) {
-  if(length(x) == 1 && x==0)
-    logi32(...)
-  else
-    logi32(length(x), ...)
+  logi32(...)
 }
 
 normalize.endianness <- function(endian)
@@ -86,110 +66,109 @@ char <- C_char <- function(length=NULL, enc=NULL, nul=TRUE, sample=NULL) {
   if(is.null(length)) { # a char byte
     structure(raw(0), bytes=1L, signed=1L, class=c("Ctype","char"))
   } else {
-    structure(character(max(length,1)+!!nul), bytes=as.integer(max(length,1)+!!nul), signed=0L,
+    structure(character(0), bytes=as.integer(max(length,1)+!!nul), signed=0L,
               enc=enc, nul=nul, class=c("Ctype","char","string"))
   }
 }
-
 as.char <- function(x, ...) UseMethod("as.char")
-as.char.mmap <- function(x, length, ...) {
-  x$storage.mode <- char(length)
+as.char.mmap <- function(x, ...) {
+  x$storage.mode <- char(...)
   x
 }
 
-uchar <- C_uchar <- function(length=0) {
-  structure(raw(length), bytes=1L, signed=0L, class=c("Ctype","uchar"))
+uchar <- C_uchar <- function() {
+  structure(raw(0), bytes=1L, signed=0L, class=c("Ctype","uchar"))
 }
 as.uchar <- function(x, ...) UseMethod("as.uchar")
-as.uchar.mmap <- function(x, length, ...) {
-  x$storage.mode <- uchar(length)
+as.uchar.mmap <- function(x, ...) {
+  x$storage.mode <- uchar(...)
   x 
 }
 
-int8 <- function(length=0) {
-  structure(integer(length), bytes=1L, signed=1L, class=c("Ctype","char"))
+int8 <- function() {
+  structure(integer(0), bytes=1L, signed=1L, class=c("Ctype","char"))
 }
-as.int8 <- function(x, length, ...) UseMethod("as.int8")
-as.int8.mmap <- function(x, length=0, ...) {
-  x$storage.mode <- int8(length)
+as.int8 <- function(x, ...) UseMethod("as.int8")
+as.int8.mmap <- function(x, ...) {
+  x$storage.mode <- int8(...)
   x
 }
 
-uint8 <- function(length=0) {
-  structure(integer(length), bytes=1L, signed=0L, class=c("Ctype","uchar"))
+uint8 <- function() {
+  structure(integer(0), bytes=1L, signed=0L, class=c("Ctype","uchar"))
 }
-as.uint8 <- function(x, length, ...) UseMethod("as.uint8")
-as.uint8.mmap <- function(x, length=0, ...) {
-  x$storage.mode <- uint8(length)
+as.uint8 <- function(x, ...) UseMethod("as.uint8")
+as.uint8.mmap <- function(x, ...) {
+  x$storage.mode <- uint8(...)
   x
 }
 
-int16 <- C_short <- function(length=0, endian=c("big", "little", "swap", "platform")) {
+int16 <- C_short <- function(endian=c("big", "little", "swap", "platform")) {
   endian <- normalize.endianness(match.arg(endian))
-  structure(integer(length), bytes=2L, signed=1L, endian=endian, class=c("Ctype","short"))
+  structure(integer(0), bytes=2L, signed=1L, endian=endian, class=c("Ctype","short"))
 }
-as.int16 <- function(x, length, ...) UseMethod("as.int16")
-as.int16.mmap <- function(x, length=0, ...) {
-  x$storage.mode <- int16(length)
+as.int16 <- function(x, ...) UseMethod("as.int16")
+as.int16.mmap <- function(x, ...) {
+  x$storage.mode <- int16(...)
   x
 }
 
-uint16 <- C_ushort <- function(length=0, endian=c("big", "little", "swap", "platform")) {
+uint16 <- C_ushort <- function(endian=c("big", "little", "swap", "platform")) {
   endian <- normalize.endianness(match.arg(endian))
-  structure(integer(length), bytes=2L, signed=0L, endian=endian, class=c("Ctype","ushort"))
+  structure(integer(0), bytes=2L, signed=0L, endian=endian, class=c("Ctype","ushort"))
 }
-as.uint16 <- function(x, length, ...) UseMethod("as.uint16")
-as.uint16.mmap <- function(x, length=0, ...) {
-  x$storage.mode <- uint16(length)
+as.uint16 <- function(x, ...) UseMethod("as.uint16")
+as.uint16.mmap <- function(x, ...) {
+  x$storage.mode <- uint16(...)
   x
 }
 
-int32 <- C_int <- function(length=0, endian=c("big", "little", "swap", "platform")) {
+int32 <- C_int <- function(endian=c("big", "little", "swap", "platform")) {
   endian <- normalize.endianness(match.arg(endian))
-  structure(integer(length), bytes=4L, signed=1L, endian=endian, class=c("Ctype","int"))
+  structure(integer(0), bytes=4L, signed=1L, endian=endian, class=c("Ctype","int"))
 }
 
-int64 <- C_int64 <- function(length=0, endian=c("big", "little", "swap", "platform")) {
+int64 <- C_int64 <- function(endian=c("big", "little", "swap", "platform")) {
   endian <- normalize.endianness(match.arg(endian))
   # currently untested and experimental. Will lose precision in R though we cast
   # to a double precision float to minimize the damage
   if(.Machine$sizeof.long != 8)
     warning("unsupported int64, use int32 or real64")
-  structure(double(length), bytes=as.integer(.Machine$sizeof.long), signed=1L, endian=endian, class=c("Ctype","int64"))
+  structure(double(0), bytes=as.integer(.Machine$sizeof.long), signed=1L, endian=endian, class=c("Ctype","int64"))
 }
 
-uint32 <- C_uint <- function(length=0, endian=c("big", "little", "swap", "platform")) {
+uint32 <- C_uint <- function(endian=c("big", "little", "swap", "platform")) {
   endian <- normalize.endianness(match.arg(endian))
-  structure(integer(length), bytes=4L, signed=0L, endian=endian, class=c("Ctype","uint"))
+  structure(integer(0), bytes=4L, signed=0L, endian=endian, class=c("Ctype","uint"))
 }
 
-real32 <- C_float <- function(length=0, endian=c("big", "little", "swap", "platform")) { 
+real32 <- C_float <- function(endian=c("big", "little", "swap", "platform")) { 
   endian <- normalize.endianness(match.arg(endian))
-  structure(double(length),  bytes=4L, signed=1L, endian=endian, class=c("Ctype","float"))
+  structure(double(0),  bytes=4L, signed=1L, endian=endian, class=c("Ctype","float"))
 }
 
-real64 <- C_double <- function(length=0, endian=c("big", "little", "swap", "platform")) { 
+real64 <- C_double <- function(endian=c("big", "little", "swap", "platform")) { 
   endian <- normalize.endianness(match.arg(endian))
-  structure(double(length),  bytes=8L, signed=1L, endian=endian, class=c("Ctype","double"))
+  structure(double(0),  bytes=8L, signed=1L, endian=endian, class=c("Ctype","double"))
 }
 
-cplx <- C_complex <- function(length=0, endian=c("big", "little", "swap", "platform")) {
+cplx <- C_complex <- function(endian=c("big", "little", "swap", "platform")) {
   endian <- normalize.endianness(match.arg(endian))
-  structure(complex(length),  bytes=16L, signed=1L, endian=endian, class=c("Ctype","complex"))
+  structure(complex(0),  bytes=16L, signed=1L, endian=endian, class=c("Ctype","complex"))
 }
 
-bits <- C_bits <- function(length=0, endian=c("big", "little", "swap", "platform")) {
+bits <- C_bits <- function(endian=c("big", "little", "swap", "platform")) {
   endian <- normalize.endianness(match.arg(endian))
-  structure(logical(length), bytes=4L, signed=0L, endian=endian, class=c("Ctype", "bits"))
+  structure(logical(0), bytes=4L, signed=0L, endian=endian, class=c("Ctype", "bits"))
 }
 
-logi32 <- C_logi <- function(length=0, endian=c("big", "little", "swap", "platform")) {
+logi32 <- C_logi <- function(endian=c("big", "little", "swap", "platform")) {
   endian <- normalize.endianness(match.arg(endian))
-  structure(logical(length), bytes=4L, signed=0L, endian=endian, class=c("Ctype", "logi32"))
+  structure(logical(0), bytes=4L, signed=0L, endian=endian, class=c("Ctype", "logi32"))
 }
 
-logi8 <- C_logi <- function(length=0) {
-  structure(logical(length), bytes=1L, signed=0L, class=c("Ctype", "logi8"))
+logi8 <- C_logi <- function() {
+  structure(logical(0), bytes=1L, signed=0L, class=c("Ctype", "logi8"))
 }
 
 pad <- C_pad <- function(...) {

--- a/pkg/mmap/R/types.R
+++ b/pkg/mmap/R/types.R
@@ -33,6 +33,9 @@ as.Ctype.complex <- function(x, ...) {
 as.Ctype.logical <- function(x, ...) {
   logi32(...)
 }
+as.Ctype.NULL <- function(x, ...) {
+  pad(...)
+}
 
 normalize.endianness <- function(endian)
   switch(endian, big="big", little="little", platform=.Platform$endian,
@@ -251,13 +254,7 @@ is.struct <- function(x) {
   inherits(x, "struct")
 }
 
-as.struct <- function(x, ...) {
-  UseMethod("as.struct")
-}
-
-as.struct.struct <- function(x, ...) x
-
-as.struct.default <- function(x, ...) {
+as.Ctype.default <- function(x, ...) {
   # According to src/main/util.c#TypeTable, src/main/coerce.c#do_is, and src/include/Rinlinedfuns.h#isFunction,
   #  some functions of interest are implemented as:
   #   is.atomic(x)    <- typeof(x) %in% c("NULL", "char", "logical", "integer", "double", "complex", "character", "raw")
@@ -271,10 +268,10 @@ as.struct.default <- function(x, ...) {
   # Since the error message will still be legible in the end, it is acceptable to just use the condition `is.recursive(x)` for simplicity.
   if (is.atomic(x))
     # Single field.
-    struct(as.Ctype(x))
+    stop(paste("Vector of class '", class(x)[1], "' is unsupported", sep = ""))
   else if (is.recursive(x))
     # Multiple fields.
-    do.call(struct, lapply(x, as.Ctype))
+    do.call(struct, c(lapply(x, as.Ctype), list(...)))
   else
     # stopifnot(typeof(x) %in% c("symbol", "externalptr", "bytecode", "weakref", "S4"))
     stop(paste("Low-level language type '", typeof(x), "' is unsupported", sep = ""))

--- a/pkg/mmap/R/types.R
+++ b/pkg/mmap/R/types.R
@@ -144,21 +144,6 @@ as.uint16.mmap <- function(x, length=0, ...) {
   x
 }
 
-int24 <- C_int24 <- function(length=0, endian=c("big", "little", "swap", "platform")) {
-  endian <- normalize.endianness(match.arg(endian))
-  structure(integer(length), bytes=3L, signed=1L, endian=endian, class=c("Ctype","int24"))
-}
-as.int24 <- function(x, length, ...) UseMethod("as.int24")
-as.int24.mmap <- function(x, length=0, ...) {
-  x$storage.mode <- int24(length)
-  x
-}
-
-uint24 <- C_uint24 <- function(length=0, endian=c("big", "little", "swap", "platform")) {
-  endian <- normalize.endianness(match.arg(endian))
-  structure(integer(length), bytes=3L, signed=0L, endian=endian, class=c("Ctype","uint24"))
-}
-
 int32 <- C_int <- function(length=0, endian=c("big", "little", "swap", "platform")) {
   endian <- normalize.endianness(match.arg(endian))
   structure(integer(length), bytes=4L, signed=1L, endian=endian, class=c("Ctype","int"))

--- a/pkg/mmap/src/mmap.c
+++ b/pkg/mmap/src/mmap.c
@@ -71,7 +71,7 @@ Comments, criticisms, and concerns should be directed
 to the maintainer of the package.
 */
 
-/* initialize bitmask for bits() type {{{*/
+/* initialize bitmask for bitset() type {{{*/
 int bitmask[32];
 int nbitmask[32];
 
@@ -424,7 +424,7 @@ SEXP mmap_extract (SEXP index, SEXP field, SEXP dim, SEXP mmap_obj, SEXP swap_by
   switch(mode) {
   case LGLSXP: /* {{{ */
     /* FIXME Need bound checking */
-    if( strcmp(MMAP_CTYPE(mmap_obj), "bits") == 0) { /* bits */
+    if( strcmp(MMAP_CTYPE(mmap_obj), "bitset") == 0) { /* bitset */
       lgl_dat = LOGICAL(dat);
       for(i=0;  i < LEN; i++) {
         long which_word = (long) ((long)(index_p[i]-1)/32);
@@ -440,12 +440,12 @@ SEXP mmap_extract (SEXP index, SEXP field, SEXP dim, SEXP mmap_obj, SEXP swap_by
     } else {
       lgl_dat = LOGICAL(dat);
       switch(Cbytes) {
-        case sizeof(char): /* logi8 */
+        case sizeof(char): /* bool8 */
           for(i=0;  i < LEN; i++) {
             lgl_dat[i] = (int)(unsigned char)(data[((long)index_p[i]-1)]);
           }
           break;
-        case sizeof(int): /* logi32 */
+        case sizeof(int): /* bool32 */
           swap = LOGICAL(swap_byte_order)[0];
           for(i=0;  i < LEN; i++) {
             memcpy(&intbuf, 
@@ -752,8 +752,9 @@ SEXP mmap_extract (SEXP index, SEXP field, SEXP dim, SEXP mmap_obj, SEXP swap_by
             }
             break;
             case sizeof(double): /* 8 byte */
+            /* get.Ctype() */
             if( strcmp(CHAR(STRING_ELT(getAttrib(VECTOR_ELT(MMAP_SMODE(mmap_obj), v),
-                                                 R_ClassSymbol),1)),"int64") == 0) { 
+                                                 R_ClassSymbol),0)),"int64") == 0) { 
               /* casting from int64 to R double to minimize precision loss */
               for(ii=0;  ii < LEN; ii++) {
                 memcpy(&longbuf, 
@@ -884,7 +885,7 @@ SEXP mmap_replace (SEXP index, SEXP field, SEXP value, SEXP mmap_obj, SEXP swap_
   case LGLSXP:
     lgl_value = LOGICAL(value);
     upper_bound = (MMAP_SIZE(mmap_obj)-Cbytes); 
-    if( strcmp(MMAP_CTYPE(mmap_obj), "bits") == 0) {  /* bits() */
+    if( strcmp(MMAP_CTYPE(mmap_obj), "bitset") == 0) {  /* bitset() */
       for(i=0; i < LEN; i++) {
         which_word = (long) (((long)index_p[i]-1)/32);
         memcpy(&int_buf, &(data[which_word]), sizeof(int));
@@ -897,7 +898,7 @@ SEXP mmap_replace (SEXP index, SEXP field, SEXP value, SEXP mmap_obj, SEXP swap_
       }
     } else {
     switch(Cbytes) {
-      case sizeof(char): /* logi8 */
+      case sizeof(char): /* bool8 */
         for(i=0; i < LEN; i++) {
           ival = ((long)index_p[i]-1)*sizeof(char);
           if( ival > upper_bound || ival < 0 )
@@ -906,7 +907,7 @@ SEXP mmap_replace (SEXP index, SEXP field, SEXP value, SEXP mmap_obj, SEXP swap_
           memcpy(&(data[((long)index_p[i]-1)*sizeof(char)]), &(char_value), sizeof(char));
         }
         break;
-      case sizeof(int): /* logi32 */
+      case sizeof(int): /* bool32 */
         swap = LOGICAL(swap_byte_order)[0];
         for(i=0; i < LEN; i++) {
           ival = ((long)index_p[i]-1)*sizeof(int);
@@ -1244,7 +1245,7 @@ SEXP mmap_compare (SEXP compare_to, SEXP compare_how, SEXP mmap_obj) {
   switch(mode) {
   case LGLSXP:
     cmp_to_int = INTEGER(coerceVector(compare_to,INTSXP))[0];
-    /* bits, lgl8, lgl32 */
+    /* bitset, bool8, bool32 */
     switch(Cbytes) {
       case sizeof(char):
         if(cmp_how==1) {

--- a/pkg/mmap/src/mmap.h
+++ b/pkg/mmap/src/mmap.h
@@ -7,21 +7,17 @@
 */
 
 #define MMAP_DATA(mmap_object)        R_ExternalPtrAddr(findVar(install("data"),mmap_object))
-#define MMAP_SIZE(mmap_object)        (long)REAL(findVar(install("bytes"),mmap_object))[0]
-#define MMAP_FD(mmap_object)          INTEGER(findVar(install("filedesc"),mmap_object))[0]
-#define MMAP_MODE(mmap_object)        TYPEOF(findVar(install("storage.mode"),mmap_object))
+#define MMAP_SIZE(mmap_object)        asInteger(findVar(install("bytes"),mmap_object))
+#define MMAP_FD(mmap_object)          asInteger(findVar(install("filedesc"),mmap_object))
 #define MMAP_SMODE(mmap_object)       findVar(install("storage.mode"),mmap_object)
-#define MMAP_CTYPE(mmap_object)       CHAR(STRING_ELT(getAttrib(findVar(install("storage.mode"), \
-                                        mmap_object), R_ClassSymbol),0)) /* get.Ctype() */
-#define MMAP_CBYTES(mmap_object)      INTEGER(getAttrib(findVar(install("storage.mode"), \
-                                        mmap_object),install("bytes")))[0]
-#define MMAP_SIGNED(mmap_object)      INTEGER(getAttrib(findVar(install("storage.mode"), \
-                                        mmap_object),install("signed")))[0]
-#define MMAP_OFFSET(mmap_object,i)      INTEGER(getAttrib(findVar(install("storage.mode"), \
-                                        mmap_object),install("offset")))[i]
-#define MMAP_PAGESIZE(mmap_object)    INTEGER(findVar(install("pagesize"),mmap_object))[0]
+#define SMODE_CTYPE(smode)            CHAR(STRING_ELT(getAttrib(smode, R_ClassSymbol),0)) /* get.Ctype() */
+#define SMODE_CBYTES(smode)           asInteger(getAttrib(smode,install("bytes")))
+#define SMODE_SIGNED(smode)           asLogical(getAttrib(smode,install("signed")))
+#define SMODE_OFFSET(smode,i)         INTEGER(getAttrib(smode,install("offset")))[i]
+#define SMODE_NUL_TERM(smode)         (isNull(getAttrib(smode,install("nul"))) || asLogical(getAttrib(smode,install("nul"))))
+#define MMAP_PAGESIZE(mmap_object)    asInteger(findVar(install("pagesize"),mmap_object))
 #define MMAP_DIM(mmap_object)         findVar(install("dim"),mmap_object)
-#define MMAP_SYNC(mmap_object)        INTEGER(VECTOR_ELT(mmap_object,4))[0]
+#define MMAP_SYNC(mmap_object)        asInteger(VECTOR_ELT(mmap_object,4))
 
 /*
 #define MMAP_DATA(mmap_object)        R_ExternalPtrAddr(VECTOR_ELT(mmap_object,0))

--- a/pkg/mmap/src/mmap.h
+++ b/pkg/mmap/src/mmap.h
@@ -12,7 +12,7 @@
 #define MMAP_MODE(mmap_object)        TYPEOF(findVar(install("storage.mode"),mmap_object))
 #define MMAP_SMODE(mmap_object)       findVar(install("storage.mode"),mmap_object)
 #define MMAP_CTYPE(mmap_object)       CHAR(STRING_ELT(getAttrib(findVar(install("storage.mode"), \
-                                        mmap_object), R_ClassSymbol),1))
+                                        mmap_object), R_ClassSymbol),0)) /* get.Ctype() */
 #define MMAP_CBYTES(mmap_object)      INTEGER(getAttrib(findVar(install("storage.mode"), \
                                         mmap_object),install("bytes")))[0]
 #define MMAP_SIGNED(mmap_object)      INTEGER(getAttrib(findVar(install("storage.mode"), \

--- a/pkg/mmap/tests/integers.R
+++ b/pkg/mmap/tests/integers.R
@@ -85,46 +85,6 @@ test.uint16 <- function(on=TRUE) {
 
 
 
-#### int24() ####
-test.int24 <- function(on=TRUE) {
-  cat("checking test.int24...")
-  if( !isTRUE(on)) {
-    cat("test.int24 disabled\n")
-    return(NULL)
-  }
-  ints <- as.integer(seq(-8388607L,8388607L,length.out=11))
-  writeBin(rep(as.raw(0),33), tmp)
-  m <- mmap(tmp, int24())  # signed 3 byte integers
-  m[] <- ints
-  if( !all(m[] == ints) )
-    stop("m[] == ints")
-  munmap(m)
-  cat("OK\n")
-}
-
-
-
-
-#### uint24() ####
-test.uint24 <- function(on=TRUE) {
-  cat("checking test.uint24...")
-  if( !isTRUE(on)) {
-    cat("test.uint24 disabled\n")
-    return(NULL)
-  }
-  ints <- as.integer(seq(0,16777215L,length.out=100))
-  writeBin(rep(as.raw(0),300), tmp)
-  m <- mmap(tmp, uint24())  # signed 3 byte integers
-  m[] <- ints
-  if( !all(m[] == ints) )
-    stop("m[] == ints")
-  munmap(m)
-  cat("OK\n")
-}
-
-
-
-
 #### int32() ####
 test.int32 <- function(on=TRUE) {
   cat("checking test.int32...")
@@ -168,7 +128,5 @@ test.int8()
 test.uint8()
 test.int16()
 test.uint16()
-test.int24()
-test.uint24()
 test.int32()
 test.int64(FALSE)


### PR DESCRIPTION
Resolve #12. Resolve #15. Resolve #1. Remove the `int24` and `uint24` subclasses of `Ctype` because they are not fully supported in `mmap_extract()` and `mmap_replace()`. Fix unnecessary memory usage of `Ctype` objects produced by the `as.Ctype()` functions. Harmonize the different `as.mmap()` overrides. Split the `char` subclass of `Ctype` into three cases due to incompatible structures of the `Ctype` object. Harmonize the logic of atomic vectors at the top-level of a `mmap` object and for atomic vectors that are part of a `mmap` object of `struct` type. Implement full support for the `logi8` and `logi32` subclasses of `Ctype`. Some work was also done to pave the way for #13.